### PR TITLE
Fix Route53 provider inifite loop when there's only a few records in AWS account

### DIFF
--- a/pkg/provider/route53.go
+++ b/pkg/provider/route53.go
@@ -42,8 +42,8 @@ func (p *Route53Provider) getResourceRecordSets() (sourceResourceRecordSet *rout
 	var startRecordIdentifier *string
 	var startRecordName = aws.String(p.config.RecordName)
 	var startRecordType *string
-	var isTruncated = false
-	for !isTruncated {
+	var isTruncated = true
+	for isTruncated {
 		res, err := p.client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
 			HostedZoneId:          aws.String(p.config.HostedZoneId),
 			StartRecordIdentifier: startRecordIdentifier,


### PR DESCRIPTION
Each record's `IsTruncated` is set to `true` only when there's more records to read.
Therefore, this `for` has been an infinite loop when IsTruncated is always `false`, which can happen when there are only a few records that fit within one page.