### PR TITLE
change to better filter record sets in route53 provider

### DIFF
--- a/pkg/provider/route53.go
+++ b/pkg/provider/route53.go
@@ -78,11 +78,15 @@ func (p *Route53Provider) getResourceRecordSets() (src *route53.ResourceRecordSe
 			if src != nil && dest != nil {
 				break
 			}
-			if p.config.Type != "" && !p.matchPattern(p.config.Type, p.config.TypeRegexp, aws.StringValue(r.Type)) {
-				continue
+			if p.config.Type != "" || p.config.TypeRegexp != nil {
+				if !p.matchPattern(p.config.Type, p.config.TypeRegexp, aws.StringValue(r.Type)) {
+					continue
+				}
 			}
-			if p.config.RecordName != "" && !p.matchPattern(p.config.RecordName, p.config.RecordNameRegexp, aws.StringValue(r.Name)) {
-				continue
+			if p.config.RecordName != "" || p.config.RecordNameRegexp != nil {
+				if !p.matchPattern(p.config.RecordName, p.config.RecordNameRegexp, aws.StringValue(r.Name)) {
+					continue
+				}
 			}
 			if p.matchPattern(p.config.SourceIdentifier, p.config.SourceIdentifierRegexp, aws.StringValue(r.SetIdentifier)) {
 				src = r
@@ -161,6 +165,9 @@ func NewRoute53Provider(config *Route53Confg) (*Route53Provider, error) {
 	if config.DestinationIdentifier == "" && config.DestinationIdentifierRegexp == nil {
 		return nil, errors.New("Route53Config.DestinationIdentifier or Route53Config.DestinationIdentifierRegexp must be set")
 	}
+	config.DestinationIdentifier = ""
+	config.DestinationIdentifierRegexp = regexp.MustCompile(`^.*$`)
+
 
 	client := config.Client
 


### PR DESCRIPTION
More flexible and efficient record retrieval with `Route53 Provider`.

- `RecordName` is no longer required
- Now filter by `Type` (A, AAAA, CNAME, etc.)
- `RecordName`, `Type` and `Identifier` are now matched by substrings or regular expressions
- Allow API calls to filter `RecordName` if it is a full name
- API calls are now filtered for `Type`